### PR TITLE
Allowance Wallet Smart Contract (Clarity)

### DIFF
--- a/panc_contrants/Clarinet.toml
+++ b/panc_contrants/Clarinet.toml
@@ -5,6 +5,11 @@ authors = []
 telemetry = true
 cache_dir = '.\.cache'
 requirements = []
+[contracts.allowance_wallet]
+path = 'contracts/allowance_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.restricted_storage]
 path = 'contracts/restricted_storage.clar'
 clarity_version = 2

--- a/panc_contrants/contracts/allowance_wallet.clar
+++ b/panc_contrants/contracts/allowance_wallet.clar
@@ -1,0 +1,143 @@
+;; Allowance Wallet Smart Contract
+;; Allows owner to set allowances for users who can withdraw up to their limit
+
+;; Constants
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_UNAUTHORIZED (err u100))
+(define-constant ERR_INSUFFICIENT_ALLOWANCE (err u101))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u102))
+(define-constant ERR_INVALID_AMOUNT (err u103))
+
+;; Data Variables
+(define-data-var contract-balance uint u0)
+
+;; Data Maps
+;; Maps user principal to their allowance amount
+(define-map allowances principal uint)
+
+;; Maps user principal to their spent amount
+(define-map spent-amounts principal uint)
+
+;; Private Functions
+
+;; Get the current allowance for a user
+(define-private (get-allowance (user principal))
+  (default-to u0 (map-get? allowances user)))
+
+;; Get the amount already spent by a user
+(define-private (get-spent-amount (user principal))
+  (default-to u0 (map-get? spent-amounts user)))
+
+;; Calculate remaining allowance for a user
+(define-private (get-remaining-allowance (user principal))
+  (let ((allowance (get-allowance user))
+        (spent (get-spent-amount user)))
+    (if (>= spent allowance)
+        u0
+        (- allowance spent))))
+
+;; Public Functions
+
+;; Deposit STX into the contract (only owner)
+(define-public (deposit (amount uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    (var-set contract-balance (+ (var-get contract-balance) amount))
+    (ok amount)))
+
+;; Set allowance for a user (only owner)
+(define-public (set-allowance (user principal) (amount uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (map-set allowances user amount)
+    (ok amount)))
+
+;; Increase allowance for a user (only owner)
+(define-public (increase-allowance (user principal) (amount uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+    (let ((current-allowance (get-allowance user)))
+      (map-set allowances user (+ current-allowance amount))
+      (ok (+ current-allowance amount)))))
+
+;; Decrease allowance for a user (only owner)
+(define-public (decrease-allowance (user principal) (amount uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+    (let ((current-allowance (get-allowance user)))
+      (if (>= current-allowance amount)
+          (begin
+            (map-set allowances user (- current-allowance amount))
+            (ok (- current-allowance amount)))
+          (begin
+            (map-delete allowances user)
+            (ok u0))))))
+
+;; Withdraw STX from allowance
+(define-public (withdraw (amount uint))
+  (let ((remaining-allowance (get-remaining-allowance tx-sender))
+        (current-balance (var-get contract-balance))
+        (current-spent (get-spent-amount tx-sender)))
+    (begin
+      (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+      (asserts! (<= amount remaining-allowance) ERR_INSUFFICIENT_ALLOWANCE)
+      (asserts! (<= amount current-balance) ERR_INSUFFICIENT_BALANCE)
+      (try! (as-contract (stx-transfer? amount tx-sender tx-sender)))
+      (var-set contract-balance (- current-balance amount))
+      (map-set spent-amounts tx-sender (+ current-spent amount))
+      (ok amount))))
+
+;; Reset spent amount for a user (only owner)
+(define-public (reset-spent-amount (user principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (map-delete spent-amounts user)
+    (ok true)))
+
+;; Remove allowance for a user (only owner)
+(define-public (remove-allowance (user principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+    (map-delete allowances user)
+    (map-delete spent-amounts user)
+    (ok true)))
+
+;; Emergency withdraw all funds (only owner)
+(define-public (emergency-withdraw)
+  (let ((current-balance (var-get contract-balance)))
+    (begin
+      (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+      (asserts! (> current-balance u0) ERR_INSUFFICIENT_BALANCE)
+      (try! (as-contract (stx-transfer? current-balance tx-sender CONTRACT_OWNER)))
+      (var-set contract-balance u0)
+      (ok current-balance))))
+
+;; Read-only Functions
+
+;; Get contract balance
+(define-read-only (get-contract-balance)
+  (var-get contract-balance))
+
+;; Get user's allowance
+(define-read-only (get-user-allowance (user principal))
+  (get-allowance user))
+
+;; Get user's spent amount
+(define-read-only (get-user-spent (user principal))
+  (get-spent-amount user))
+
+;; Get user's remaining allowance
+(define-read-only (get-user-remaining-allowance (user principal))
+  (get-remaining-allowance user))
+
+;; Check if user has allowance
+(define-read-only (has-allowance (user principal))
+  (> (get-allowance user) u0))
+
+;; Get contract owner
+(define-read-only (get-contract-owner)
+  CONTRACT_OWNER)

--- a/panc_contrants/tests/allowance_wallet.test.ts
+++ b/panc_contrants/tests/allowance_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Allowance Wallet — README

## Overview

**Allowance Wallet** is a Clarity smart contract that lets the contract owner deposit STX and assign per-user allowances. Allowed users can withdraw up to their remaining allowance. The contract tracks how much each user has spent and provides owner-only management functions (set/increase/decrease/remove allowances, reset spent amounts, and emergency withdraw).

This README explains the contract’s purpose, public interface, errors, examples, and security considerations.

---

## Key Concepts

* **Owner** — the deployer (the `tx-sender` at deployment) and stored in the constant `CONTRACT_OWNER`. Only the owner can perform administrative actions.
* **Allowances** — amounts assigned (by owner) to principals (users). Stored in the `allowances` map.
* **Spent amounts** — amount each user has withdrawn so far. Stored in the `spent-amounts` map.
* **Contract balance** — tracked in `contract-balance` variable; owner must deposit STX into the contract before users can withdraw.

---

## Error codes

The contract exposes these error constants (used with `asserts!`):

* `ERR_UNAUTHORIZED` — owner-only action attempted by non-owner. `(err u100)`
* `ERR_INSUFFICIENT_ALLOWANCE` — withdrawal amount exceeds remaining allowance. `(err u101)`
* `ERR_INSUFFICIENT_BALANCE` — contract does not have enough STX. `(err u102)`
* `ERR_INVALID_AMOUNT` — provided amount is zero or otherwise invalid. `(err u103)`

---

## Public / Read-only Interface

### Owner-only (administrative)

* `deposit (amount uint) : (response uint error)`
  Owner deposits `amount` STX to the contract. Updates `contract-balance`.

* `set-allowance (user principal) (amount uint) : (response uint error)`
  Set `user` allowance to `amount`.

* `increase-allowance (user principal) (amount uint) : (response uint error)`
  Increase `user` allowance by `amount`.

* `decrease-allowance (user principal) (amount uint) : (response uint error)`
  Decrease `user` allowance by `amount`. If the decrease equals or exceeds the current allowance, the allowance entry is deleted and treated as zero.

* `reset-spent-amount (user principal) : (response bool error)`
  Remove the `spent-amounts` entry for `user` (resets spent to zero).

* `remove-allowance (user principal) : (response bool error)`
  Remove both `allowances` and `spent-amounts` entries for `user`.

* `emergency-withdraw : (response uint error)`
  Owner withdraws entire contract balance to the owner. Sets `contract-balance` to zero.

### User-facing (allowance / withdrawal)

* `withdraw (amount uint) : (response uint error)`
  Called by a user (tx-sender). Withdraws up to the user’s remaining allowance and the contract’s balance; updates `spent-amounts` and `contract-balance`.

### Read-only views

* `get-contract-balance : uint` — returns `contract-balance`.
* `get-user-allowance (user principal) : uint` — returns allowance for `user` (0 if none).
* `get-user-spent (user principal) : uint` — returns spent amount for `user` (0 if none).
* `get-user-remaining-allowance (user principal) : uint` — allowance minus spent (floors at 0).
* `has-allowance (user principal) : bool` — true if allowance > 0.
* `get-contract-owner : principal` — returns `CONTRACT_OWNER`.

---

## Example flows

### 1) Owner deposits funds

1. Owner calls `deposit` with `amount = 100_000_000u` (for example).
2. Contract receives STX and `contract-balance` is increased by that amount.

### 2) Owner sets allowance

1. Owner calls `set-allowance` for `userA` with `amount = 10_000_000u`.
2. `allowances[userA] = 10_000_000`.

### 3) User withdraws

1. `userA` calls `withdraw` with `amount = 2_000_000u`.
2. Contract checks remaining allowance and contract balance, transfers STX, updates `spent-amounts[userA] += 2_000_000` and reduces `contract-balance`.

### 4) Owner updates allowance or resets spent

* Owner can `increase-allowance`, `decrease-allowance`, `remove-allowance`, or `reset-spent-amount` as needed.

### 5) Emergency

* If needed, owner calls `emergency-withdraw` to pull all STX from the contract.

---

## Notes & Implementation Details

* `CONTRACT_OWNER` constant is set to `tx-sender` at contract definition time — meaning the deployer becomes the immutable owner as written in the contract.
* Every withdrawal updates `spent-amounts` to prevent users from exceeding their total allowance across multiple transactions.
* `get-remaining-allowance` computes `allowance - spent` and floors to zero if spent ≥ allowance.
* `deposit` and `withdraw` use Clarity STX transfer primitives (`stx-transfer?` / `as-contract`) to move STX.

---

## Security & UX considerations

* **Owner private key**: keep the deployer’s key secure — owner-only functions are powerful (including `emergency-withdraw`).
* **Re-entrancy**: Clarity is a decidable language without the same reentrancy model as EVM; nevertheless, be cautious with external calls and ensure `stx-transfer?` usage is correct (contract-level transfers use `as-contract`).
* **Allowance lifecycle**: when decreasing allowance beyond current allowance the contract deletes the allowance (treats it as zero). Ensure the front-end or integration matches this behavior.
* **Auditing**: keep on-chain logs or off-chain indexing to track allowance assignments and spends for auditability (the contract itself stores allowance and spent maps).
* **Zero amounts**: `ERR_INVALID_AMOUNT` guards against passing zero as an amount to public functions that expect positive values.

---

## Testing suggestions

* Test owner-only guards by attempting admin calls from non-owner principals.
* Test withdraw flows:

  * withdraw exactly the allowance,
  * withdraw in several partial calls until allowance exhausted,
  * attempt to withdraw more than remaining allowance and expect `ERR_INSUFFICIENT_ALLOWANCE`.
* Test contract balance edge cases:

  * withdraw when contract balance < user remaining allowance — expect `ERR_INSUFFICIENT_BALANCE`.
  * emergency withdraw empties contract and prevents further user withdrawals until a new deposit.
* Test allowance deletion and `reset-spent-amount` interaction.

---

## Suggested Frontend UX

* Show both `allowance`, `spent` and `remaining` to users.
* Disable withdraw button if remaining allowance is zero or contract balance is insufficient.
* Provide owner dashboard for: deposit, set/increase/decrease/remove allowances, reset spent, and emergency withdraw; include confirmations for destructive actions.

---

## License

Apache-2.0

---